### PR TITLE
Fix 1.20.2+ Eaglercraft clients failing on first packet

### DIFF
--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/handshake/VanillaInitializer.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/handshake/VanillaInitializer.java
@@ -90,6 +90,14 @@ public class VanillaInitializer {
 		try {
 			BufferUtils.writeVarInt(buffer, 0x00);
 			BufferUtils.writeMCString(buffer, pipelineData.username, 16);
+			if (pipelineData.minecraftProtocol >= 764) {
+				java.util.UUID uuid = pipelineData.uuid;
+				if (uuid == null) {
+					uuid = java.util.UUID.nameUUIDFromBytes(("OfflinePlayer:" + pipelineData.username).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+				}
+				buffer.writeLong(uuid.getMostSignificantBits());
+				buffer.writeLong(uuid.getLeastSignificantBits());
+			}
 			ctx.fireChannelRead(buffer.retain());
 		} finally {
 			buffer.release();
@@ -128,14 +136,34 @@ public class VanillaInitializer {
 					connectionState = STATE_STALLING;
 					// S02PacketLoginSuccess
 					UUID playerUUID;
-					String uuidStr = BufferUtils.readMCString(msg, 36);
-					try {
-						playerUUID = UUID.fromString(uuidStr);
-					} catch (IllegalArgumentException ex) {
-						inboundHandler.terminateInternalError(ctx, pipelineData.handshakeProtocol);
-						return;
+					String usernameStr;
+					int mcProto = pipelineData.minecraftProtocol;
+					if (mcProto >= 735) {
+						playerUUID = new UUID(msg.readLong(), msg.readLong());
+						usernameStr = BufferUtils.readMCString(msg, 16);
+						if (mcProto >= 759) {
+							int propCount = BufferUtils.readVarInt(msg, 5);
+							for (int j = 0; j < propCount; ++j) {
+								BufferUtils.readMCString(msg, 32767);
+								BufferUtils.readMCString(msg, 32767);
+								if (msg.readBoolean()) {
+									BufferUtils.readMCString(msg, 32767);
+								}
+							}
+						}
+						if (mcProto >= 766 && msg.isReadable()) {
+							msg.readBoolean();
+						}
+					} else {
+						String uuidStr = BufferUtils.readMCString(msg, 36);
+						try {
+							playerUUID = UUID.fromString(uuidStr);
+						} catch (IllegalArgumentException ex) {
+							inboundHandler.terminateInternalError(ctx, pipelineData.handshakeProtocol);
+							return;
+						}
+						usernameStr = BufferUtils.readMCString(msg, 16);
 					}
-					String usernameStr = BufferUtils.readMCString(msg, 16);
 					inboundHandler.handleBackendHandshakeSuccess(ctx, usernameStr, playerUUID);
 					break;
 				case 0x03:

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/handshake/VanillaInitializer.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/handshake/VanillaInitializer.java
@@ -91,12 +91,8 @@ public class VanillaInitializer {
 			BufferUtils.writeVarInt(buffer, 0x00);
 			BufferUtils.writeMCString(buffer, pipelineData.username, 16);
 			if (pipelineData.minecraftProtocol >= 764) {
-				java.util.UUID uuid = pipelineData.uuid;
-				if (uuid == null) {
-					uuid = java.util.UUID.nameUUIDFromBytes(("OfflinePlayer:" + pipelineData.username).getBytes(java.nio.charset.StandardCharsets.UTF_8));
-				}
-				buffer.writeLong(uuid.getMostSignificantBits());
-				buffer.writeLong(uuid.getLeastSignificantBits());
+				buffer.writeLong(pipelineData.uuid.getMostSignificantBits());
+				buffer.writeLong(pipelineData.uuid.getLeastSignificantBits());
 			}
 			ctx.fireChannelRead(buffer.retain());
 		} finally {
@@ -144,10 +140,10 @@ public class VanillaInitializer {
 						if (mcProto >= 759) {
 							int propCount = BufferUtils.readVarInt(msg, 5);
 							for (int j = 0; j < propCount; ++j) {
-								BufferUtils.readMCString(msg, 32767);
-								BufferUtils.readMCString(msg, 32767);
+								msg.skipBytes(BufferUtils.readVarInt(msg, 5));
+								msg.skipBytes(BufferUtils.readVarInt(msg, 5));
 								if (msg.readBoolean()) {
-									BufferUtils.readMCString(msg, 32767);
+									msg.skipBytes(BufferUtils.readVarInt(msg, 5));
 								}
 							}
 						}

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/WebSocketEaglerInitialHandler.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/WebSocketEaglerInitialHandler.java
@@ -659,6 +659,15 @@ public class WebSocketEaglerInitialHandler extends MessageToMessageCodec<ByteBuf
 		handshaker.finish(ctx);
 		ChannelPipeline pipeline = ctx.pipeline();
 		pipeline.fireUserEventTriggered(EnumPipelineEvent.EAGLER_HANDSHAKE_COMPLETE);
+		if (pipelineData.minecraftProtocol >= 764) {
+			io.netty.buffer.ByteBuf ackBuf = ctx.alloc().buffer();
+			try {
+				net.lax1dude.eaglercraft.backend.server.base.pipeline.BufferUtils.writeVarInt(ackBuf, 0x03);
+				ctx.fireChannelRead(ackBuf.retain());
+			} finally {
+				ackBuf.release();
+			}
+		}
 		vanillaInitializer.flushBufferedPackets(ctx);
 		pipeline.remove(PipelineTransformer.HANDLER_HANDSHAKE);
 		pipelineData.signalPlayState();

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/WebSocketEaglerInitialHandler.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/WebSocketEaglerInitialHandler.java
@@ -660,9 +660,9 @@ public class WebSocketEaglerInitialHandler extends MessageToMessageCodec<ByteBuf
 		ChannelPipeline pipeline = ctx.pipeline();
 		pipeline.fireUserEventTriggered(EnumPipelineEvent.EAGLER_HANDSHAKE_COMPLETE);
 		if (pipelineData.minecraftProtocol >= 764) {
-			io.netty.buffer.ByteBuf ackBuf = ctx.alloc().buffer();
+			ByteBuf ackBuf = ctx.alloc().buffer();
 			try {
-				net.lax1dude.eaglercraft.backend.server.base.pipeline.BufferUtils.writeVarInt(ackBuf, 0x03);
+				BufferUtils.writeVarInt(ackBuf, 0x03);
 				ctx.fireChannelRead(ackBuf.retain());
 			} finally {
 				ackBuf.release();


### PR DESCRIPTION
Updated EaglerXServer's login packet encoding to include the UUID and property data that Velocity/Bungeecord requires for 1.20.2+