### PR TITLE
Fix HAProxy auto-detection peer filtering

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,6 +28,9 @@ dependencies {
 	compileOnly(libs.guava)
 	compileOnly(libs.slf4j)
 	compileOnly(libs.skinsrestorer.api)
+	testImplementation(libs.bundles.netty.all)
+	testImplementation(libs.guava)
+	testImplementation("junit:junit:4.13.2")
 	sqliteDriver project(":skin-cache:sqlite-jdbc-jar")
 }
 

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/EaglerListener.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/EaglerListener.java
@@ -39,6 +39,7 @@ import net.lax1dude.eaglercraft.backend.server.api.attribute.IAttributeKey;
 import net.lax1dude.eaglercraft.backend.server.base.EaglerAttributeManager.EaglerAttributeHolder;
 import net.lax1dude.eaglercraft.backend.server.base.config.ConfigDataListener;
 import net.lax1dude.eaglercraft.backend.server.base.pipeline.WebSocketEaglerInitialHandler;
+import net.lax1dude.eaglercraft.backend.server.util.IPAddressSet;
 import net.lax1dude.eaglercraft.backend.server.util.RateLimiterExclusions;
 
 public class EaglerListener implements IEaglerListenerInfo, IEaglerXServerListener {
@@ -52,6 +53,7 @@ public class EaglerListener implements IEaglerListenerInfo, IEaglerXServerListen
 	private final byte[] legacyRedirectAddressBuf;
 	private byte[] cachedServerIcon;
 	private List<String> cachedServerMOTD;
+	private final IPAddressSet trustedHAProxyProxies;
 	private CompoundRateLimiterMap rateLimiter;
 
 	EaglerListener(EaglerXServer<?> server, ConfigDataListener listenerConf) throws SSLException, IOException {
@@ -98,6 +100,7 @@ public class EaglerListener implements IEaglerListenerInfo, IEaglerXServerListen
 		} else {
 			cachedServerIcon = null;
 		}
+		trustedHAProxyProxies = IPAddressSet.create(listenerConf.getTrustedHAProxyProxies());
 		rateLimiter = CompoundRateLimiterMap.create(listenerConf.getLimitIP(), listenerConf.getLimitLogin(),
 				listenerConf.getLimitMOTD(), listenerConf.getLimitQuery(), listenerConf.getLimitHTTP(),
 				RateLimiterExclusions.create(listenerConf.getLimitExclusions(), server.logger()));
@@ -105,6 +108,10 @@ public class EaglerListener implements IEaglerListenerInfo, IEaglerXServerListen
 
 	public ISSLContextProvider getSSLContext() {
 		return sslContext;
+	}
+
+	public IPAddressSet getTrustedHAProxyProxies() {
+		return trustedHAProxyProxies;
 	}
 
 	@Override

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/config/ConfigDataListener.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/config/ConfigDataListener.java
@@ -71,6 +71,7 @@ public class ConfigDataListener {
 	private final String forwardSecretValue;
 	private final boolean spoofPlayerAddressForwarded;
 	private final boolean dualStackHAProxyDetection;
+	private final List<String> trustedHAProxyProxies;
 	private final boolean forceDisableHAProxy;
 	private final boolean enableTLS;
 	private final boolean requireTLS;
@@ -102,14 +103,16 @@ public class ConfigDataListener {
 	public ConfigDataListener(String listenerName, SocketAddress injectAddress, boolean cloneListenerEnabled,
 			boolean dualStack, boolean forwardIp, String forwardIPHeader, boolean forwardSecret,
 			String forwardSecretHeader, String forwardSecretFile, String forwardSecretValue,
-			boolean spoofPlayerAddressForwarded, boolean dualStackHAProxyDetection, boolean forceDisableHAProxy,
-			boolean enableTLS, boolean requireTLS, boolean tlsManagedByExternalPlugin, String tlsPublicChainFile,
-			String tlsPrivateKeyFile, String tlsPrivateKeyPassword, boolean tlsAutoRefreshCert,
-			String redirectLegacyClientsTo, String serverIcon, List<String> serverMOTD, boolean allowMOTD,
-			boolean allowQuery, boolean showMOTDPlayerList, boolean allowCookieRevokeQuery, int motdCacheTTL,
+			boolean spoofPlayerAddressForwarded, boolean dualStackHAProxyDetection,
+			List<String> trustedHAProxyProxies, boolean forceDisableHAProxy, boolean enableTLS, boolean requireTLS,
+			boolean tlsManagedByExternalPlugin, String tlsPublicChainFile, String tlsPrivateKeyFile,
+			String tlsPrivateKeyPassword, boolean tlsAutoRefreshCert, String redirectLegacyClientsTo,
+			String serverIcon, List<String> serverMOTD, boolean allowMOTD, boolean allowQuery,
+			boolean showMOTDPlayerList, boolean allowCookieRevokeQuery, int motdCacheTTL,
 			boolean motdCacheAnimation, boolean motdCacheResults, boolean motdCacheTrending,
-			boolean motdCachePortfolios, ConfigRateLimit limitIP, ConfigRateLimit limitLogin, ConfigRateLimit limitMOTD,
-			ConfigRateLimit limitQuery, ConfigRateLimit limitHTTP, List<String> limitExclusions) {
+			boolean motdCachePortfolios, ConfigRateLimit limitIP, ConfigRateLimit limitLogin,
+			ConfigRateLimit limitMOTD, ConfigRateLimit limitQuery, ConfigRateLimit limitHTTP,
+			List<String> limitExclusions) {
 		this.listenerName = listenerName;
 		this.injectAddress = injectAddress;
 		this.cloneListenerEnabled = cloneListenerEnabled;
@@ -122,6 +125,7 @@ public class ConfigDataListener {
 		this.forwardSecretValue = forwardSecretValue;
 		this.spoofPlayerAddressForwarded = spoofPlayerAddressForwarded;
 		this.dualStackHAProxyDetection = dualStackHAProxyDetection;
+		this.trustedHAProxyProxies = trustedHAProxyProxies;
 		this.forceDisableHAProxy = forceDisableHAProxy;
 		this.enableTLS = enableTLS;
 		this.requireTLS = requireTLS;
@@ -193,6 +197,10 @@ public class ConfigDataListener {
 
 	public boolean isDualStackHAProxyDetection() {
 		return dualStackHAProxyDetection;
+	}
+
+	public List<String> getTrustedHAProxyProxies() {
+		return trustedHAProxyProxies;
 	}
 
 	public boolean isForceDisableHAProxy() {

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/config/EaglerConfigLoader.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/config/EaglerConfigLoader.java
@@ -944,6 +944,17 @@ public class EaglerConfigLoader {
 			+ "for the channel if it is not present. You must enable HAProxy on the "
 			+ "underlying BungeeCord/Velocity listener for this to work properly."
 		) : false;
+		List<String> trustedHAProxyProxies;
+		if (platform.proxy) {
+			IEaglerConfList trustedHAProxyProxiesConf = listener.getList("trusted_haproxy_proxies");
+			trustedHAProxyProxies = ImmutableList.copyOf(trustedHAProxyProxiesConf.getAsStringList(
+					() -> Collections.emptyList(),
+					"List of IPv4 and IPv6 addresses allowed to send HAProxy PROXY protocol headers "
+							+ "to this listener. CIDR notation may be used for subnets. Required when "
+							+ "dual_stack_haproxy_detection is enabled."));
+		} else {
+			trustedHAProxyProxies = Collections.emptyList();
+		}
 		boolean forceDisableHAProxy = platform.proxy ? listener.getBoolean(
 			"force_disable_haproxy", false,
 			"Default value is false, if HAProxy should be forcefully disabled when "
@@ -1092,11 +1103,12 @@ public class EaglerConfigLoader {
 						+ "ratelimits will be applied based on the forwarded address instead of the raw socket address."));
 		return new ConfigDataListener(name, injectAddress, cloneListenerEnabled, dualStack, forwardIp, forwardIPHeader,
 				forwardSecret, forwardSecretHeader, forwardSecretFile, forwardSecretValue, spoofPlayerAddressForwarded,
-				dualStackHAProxyDetection, forceDisableHAProxy, enableTLS, requireTLS, tlsManagedByExternalPlugin,
-				tlsPublicChainFile, tlsPrivateKeyFile, tlsPrivateKeyPassword, tlsAutoRefreshCert,
-				redirectLegacyClientsTo, serverIcon, serverMOTD, allowMOTD, allowQuery, showMOTDPlayerList,
-				allowCookieRevokeQuery, motdCacheTTL, motdCacheAnimation, motdCacheResults, motdCacheTrending,
-				motdCachePortfolios, limitIP, limitLogin, limitMOTD, limitQuery, limitHTTP, exceptionsConfList);
+				dualStackHAProxyDetection, trustedHAProxyProxies, forceDisableHAProxy, enableTLS, requireTLS,
+				tlsManagedByExternalPlugin, tlsPublicChainFile, tlsPrivateKeyFile, tlsPrivateKeyPassword,
+				tlsAutoRefreshCert, redirectLegacyClientsTo, serverIcon, serverMOTD, allowMOTD, allowQuery,
+				showMOTDPlayerList, allowCookieRevokeQuery, motdCacheTTL, motdCacheAnimation, motdCacheResults,
+				motdCacheTrending, motdCachePortfolios, limitIP, limitLogin, limitMOTD, limitQuery, limitHTTP,
+				exceptionsConfList);
 	}
 
 	private static ConfigDataListener.ConfigRateLimit loadRatelimiter(IEaglerConfSection parent, String name,

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/HAProxyDetectionHandler.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/HAProxyDetectionHandler.java
@@ -23,13 +23,16 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import net.lax1dude.eaglercraft.backend.server.util.IPAddressSet;
 
 public class HAProxyDetectionHandler extends ByteToMessageDecoder {
 
 	private final ChannelHandler handlerToRemove;
+	private final IPAddressSet trustedPeers;
 
-	public HAProxyDetectionHandler(ChannelHandler handlerToRemove) {
+	public HAProxyDetectionHandler(ChannelHandler handlerToRemove, IPAddressSet trustedPeers) {
 		this.handlerToRemove = handlerToRemove;
+		this.trustedPeers = trustedPeers;
 	}
 
 	@Override
@@ -62,6 +65,11 @@ public class HAProxyDetectionHandler extends ByteToMessageDecoder {
 				return;
 			}
 			ChannelPipeline pipeline = ctx.pipeline();
+			if (proxy && !trustedPeers.contains(ctx.channel().remoteAddress())) {
+				in.skipBytes(readable);
+				ctx.close();
+				return;
+			}
 			if (!proxy) {
 				pipeline.remove(handlerToRemove);
 			}

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/PipelineTransformer.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/PipelineTransformer.java
@@ -202,7 +202,8 @@ public class PipelineTransformer {
 			if (eagListener.getConfigData().isForceDisableHAProxy()) {
 				pipeline.remove(haproxy.getHandle());
 			} else if (eagListener.getConfigData().isDualStackHAProxyDetection()) {
-				pipeline.addFirst(HANDLER_HAPROXY_DETECTION, new HAProxyDetectionHandler(haproxy.getHandle()));
+				pipeline.addFirst(HANDLER_HAPROXY_DETECTION,
+						new HAProxyDetectionHandler(haproxy.getHandle(), eagListener.getTrustedHAProxyProxies()));
 			}
 		}
 		pipeline.addLast(HANDLER_OUTBOUND_THROW, OutboundPacketThrowHandler.INSTANCE);
@@ -243,7 +244,8 @@ public class PipelineTransformer {
 			if (eagListener.getConfigData().isForceDisableHAProxy()) {
 				channel.pipeline().remove(haproxy.getHandle());
 			} else if (eagListener.getConfigData().isDualStackHAProxyDetection()) {
-				channel.pipeline().addFirst(HANDLER_HAPROXY_DETECTION, new HAProxyDetectionHandler(haproxy.getHandle()));
+				channel.pipeline().addFirst(HANDLER_HAPROXY_DETECTION,
+						new HAProxyDetectionHandler(haproxy.getHandle(), eagListener.getTrustedHAProxyProxies()));
 			}
 		}
 		channel.pipeline().addLast(HANDLER_OUTBOUND_THROW, OutboundPacketThrowHandler.INSTANCE);

--- a/core/src/main/java/net/lax1dude/eaglercraft/backend/server/util/IPAddressSet.java
+++ b/core/src/main/java/net/lax1dude/eaglercraft/backend/server/util/IPAddressSet.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2025 lax1dude. All Rights Reserved.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package net.lax1dude.eaglercraft.backend.server.util;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.net.InetAddresses;
+
+import io.netty.handler.ipfilter.IpFilterRuleType;
+import io.netty.handler.ipfilter.IpSubnetFilterRule;
+
+public final class IPAddressSet {
+
+	public static IPAddressSet create(List<String> entries) {
+		List<IpSubnetFilterRule> ipv4Rules = new ArrayList<>();
+		List<IpSubnetFilterRule> ipv6Rules = new ArrayList<>();
+		for (String entry : entries) {
+			try {
+				String value = entry.trim();
+				int slash = value.lastIndexOf('/');
+				InetAddress address;
+				int prefix;
+				if (slash == -1) {
+					address = InetAddresses.forString(value);
+					prefix = address instanceof Inet4Address ? 32 : 128;
+				} else {
+					address = InetAddresses.forString(value.substring(0, slash));
+					prefix = Integer.parseInt(value.substring(slash + 1));
+				}
+				IpSubnetFilterRule rule = new IpSubnetFilterRule(address, prefix, IpFilterRuleType.ACCEPT);
+				if (address instanceof Inet4Address) {
+					ipv4Rules.add(rule);
+				} else if (address instanceof Inet6Address) {
+					ipv6Rules.add(rule);
+				} else {
+					throw new IllegalArgumentException("Unsupported IP address: " + value);
+				}
+			} catch (IllegalArgumentException ex) {
+				throw new IllegalArgumentException("Invalid IP address or subnet: \"" + entry + "\"", ex);
+			}
+		}
+		return new IPAddressSet(ImmutableList.copyOf(ipv4Rules), ImmutableList.copyOf(ipv6Rules));
+	}
+
+	private final ImmutableList<IpSubnetFilterRule> ipv4Rules;
+	private final ImmutableList<IpSubnetFilterRule> ipv6Rules;
+
+	private IPAddressSet(ImmutableList<IpSubnetFilterRule> ipv4Rules,
+			ImmutableList<IpSubnetFilterRule> ipv6Rules) {
+		this.ipv4Rules = ipv4Rules;
+		this.ipv6Rules = ipv6Rules;
+	}
+
+	public boolean contains(SocketAddress address) {
+		if (!(address instanceof InetSocketAddress inetAddress) || inetAddress.isUnresolved()) {
+			return false;
+		}
+		InetAddress addressValue = inetAddress.getAddress();
+		List<IpSubnetFilterRule> rules;
+		if (addressValue instanceof Inet4Address) {
+			rules = ipv4Rules;
+		} else if (addressValue instanceof Inet6Address) {
+			rules = ipv6Rules;
+		} else {
+			return false;
+		}
+		for (int i = 0, l = rules.size(); i < l; ++i) {
+			if (rules.get(i).matches(inetAddress)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/core/src/test/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/HAProxyDetectionHandlerTest.java
+++ b/core/src/test/java/net/lax1dude/eaglercraft/backend/server/base/pipeline/HAProxyDetectionHandlerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2025 lax1dude. All Rights Reserved.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package net.lax1dude.eaglercraft.backend.server.base.pipeline;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import net.lax1dude.eaglercraft.backend.server.util.IPAddressSet;
+
+public class HAProxyDetectionHandlerTest {
+
+	private static class TestEmbeddedChannel extends EmbeddedChannel {
+
+		private final SocketAddress remoteAddress;
+
+		private TestEmbeddedChannel(SocketAddress remoteAddress, ChannelHandler... handlers) {
+			super(handlers);
+			this.remoteAddress = remoteAddress;
+		}
+
+		@Override
+		protected SocketAddress remoteAddress0() {
+			return remoteAddress;
+		}
+
+	}
+
+	private static class RecordingHandler extends ChannelInboundHandlerAdapter {
+
+		private boolean read;
+
+		@Override
+		public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+			read = true;
+			ctx.fireChannelRead(msg);
+		}
+
+	}
+
+	@Test
+	public void rejectsProxyV2FromUnlistedPeer() {
+		RecordingHandler decoder = new RecordingHandler();
+		EmbeddedChannel channel = new TestEmbeddedChannel(new InetSocketAddress("203.0.113.8", 25565),
+				new HAProxyDetectionHandler(decoder, IPAddressSet.create(Collections.emptyList())), decoder);
+		try {
+			channel.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A,
+					0x51, 0x55, 0x49, 0x54, 0x0A }));
+			assertFalse(channel.isOpen());
+			assertFalse(decoder.read);
+		} finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	public void rejectsProxyV1FromUnlistedPeer() {
+		RecordingHandler decoder = new RecordingHandler();
+		EmbeddedChannel channel = new TestEmbeddedChannel(new InetSocketAddress("203.0.113.8", 25565),
+				new HAProxyDetectionHandler(decoder, IPAddressSet.create(Collections.emptyList())), decoder);
+		try {
+			channel.writeInbound(Unpooled.wrappedBuffer("PROXY ".getBytes(StandardCharsets.US_ASCII)));
+			assertFalse(channel.isOpen());
+			assertFalse(decoder.read);
+		} finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	public void acceptsProxyV2FromListedPeer() {
+		RecordingHandler decoder = new RecordingHandler();
+		EmbeddedChannel channel = new TestEmbeddedChannel(new InetSocketAddress("10.20.30.40", 25565),
+				new HAProxyDetectionHandler(decoder, IPAddressSet.create(Collections.singletonList("10.0.0.0/8"))),
+				decoder);
+		try {
+			assertTrue(channel.writeInbound(Unpooled.wrappedBuffer(new byte[] { 0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D,
+					0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A })));
+			assertTrue(channel.isOpen());
+			assertNotNull(channel.pipeline().context(decoder));
+			assertTrue(decoder.read);
+		} finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	public void acceptsProxyV1FromListedPeer() {
+		RecordingHandler decoder = new RecordingHandler();
+		EmbeddedChannel channel = new TestEmbeddedChannel(new InetSocketAddress("2001:db8:1::4", 25565),
+				new HAProxyDetectionHandler(decoder,
+						IPAddressSet.create(Collections.singletonList("2001:db8:1::/48"))),
+				decoder);
+		try {
+			assertTrue(channel.writeInbound(Unpooled.wrappedBuffer("PROXY ".getBytes(StandardCharsets.US_ASCII))));
+			assertTrue(channel.isOpen());
+			assertNotNull(channel.pipeline().context(decoder));
+			assertTrue(decoder.read);
+		} finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	public void acceptsDirectTrafficFromUnlistedPeer() {
+		RecordingHandler decoder = new RecordingHandler();
+		EmbeddedChannel channel = new TestEmbeddedChannel(new InetSocketAddress("203.0.113.8", 25565),
+				new HAProxyDetectionHandler(decoder, IPAddressSet.create(Collections.emptyList())), decoder);
+		try {
+			assertTrue(channel.writeInbound(
+					Unpooled.wrappedBuffer("GET / HTTP/1.1\r\n".getBytes(StandardCharsets.US_ASCII))));
+			assertTrue(channel.isOpen());
+			assertNull(channel.pipeline().context(decoder));
+			assertFalse(decoder.read);
+			ByteBuf inbound = channel.readInbound();
+			try {
+				assertEquals("GET / HTTP/1.1\r\n", inbound.toString(StandardCharsets.US_ASCII));
+			} finally {
+				inbound.release();
+			}
+		} finally {
+			channel.finishAndReleaseAll();
+		}
+	}
+
+	@Test
+	public void matchesIpv4AndIpv6Subnets() {
+		IPAddressSet addresses = IPAddressSet.create(Arrays.asList("192.0.2.0/24", "2001:db8:2::/48"));
+		assertTrue(addresses.contains(new InetSocketAddress("192.0.2.255", 1)));
+		assertFalse(addresses.contains(new InetSocketAddress("192.0.3.1", 1)));
+		assertTrue(addresses.contains(new InetSocketAddress("2001:db8:2::ffff", 1)));
+		assertFalse(addresses.contains(new InetSocketAddress("2001:db8:3::1", 1)));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void rejectsInvalidSubnet() {
+		IPAddressSet.create(Collections.singletonList("192.0.2.1/33"));
+	}
+
+}


### PR DESCRIPTION
HAProxy auto-detection previously trusted PROXY headers based only on their v1 or v2 prefix. This introduced a vulnerability where direct clients could supply a different source address.

This change adds `trusted_haproxy_proxies`, supporting IPv4, IPv6, and CIDR ranges. PROXY headers are now accepted only from configured peers, while normal direct connections continue to work unchanged.

## Testing

```powershell
.\gradlew.bat :core:test --tests "net.lax1dude.eaglercraft.backend.server.base.pipeline.HAProxyDetectionHandlerTest"
.\gradlew.bat :core:build
```