### PR TITLE
Bind the default supervisor listener to loopback

### DIFF
--- a/supervisor-core/build.gradle
+++ b/supervisor-core/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	implementation(libs.bundles.netty.supervisor)
 	runtimeOnly(libs.logback)
 	sqliteDriver project(":skin-cache:sqlite-jdbc-jar")
+	testImplementation("junit:junit:4.13.2")
 }
 
 application {

--- a/supervisor-core/src/main/resources/net/lax1dude/eaglercraft/backend/supervisor/config/default_supervisor_config.properties
+++ b/supervisor-core/src/main/resources/net/lax1dude/eaglercraft/backend/supervisor/config/default_supervisor_config.properties
@@ -1,4 +1,4 @@
-listen-addr=0.0.0.0:36900
+listen-addr=127.0.0.1:36900
 secret-key=
 read-timeout=30000
 status-http-enable=true

--- a/supervisor-core/src/test/java/net/lax1dude/eaglercraft/backend/supervisor/config/EaglerXSupervisorConfigTest.java
+++ b/supervisor-core/src/test/java/net/lax1dude/eaglercraft/backend/supervisor/config/EaglerXSupervisorConfigTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 lax1dude. All Rights Reserved.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ * WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+package net.lax1dude.eaglercraft.backend.supervisor.config;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import org.junit.Test;
+
+public class EaglerXSupervisorConfigTest {
+
+	@Test
+	public void defaultConfigUsesLoopbackSupervisorListener() throws Exception {
+		Properties properties = new Properties();
+		try (InputStream defaultConfig = EaglerXSupervisorConfig.class
+				.getResourceAsStream("default_supervisor_config.properties")) {
+			properties.load(defaultConfig);
+		}
+
+		assertEquals("127.0.0.1:36900", properties.getProperty("listen-addr"));
+	}
+
+}


### PR DESCRIPTION
The default supervisor configuration previously bound the control listener to all interfaces while leaving the shared secret empty. This introduced a vulnerability when port 36900 was network reachable.

This changes the default listener to `127.0.0.1:36900` and adds a regression test for the packaged default, existing config files are not modified automatically.

## Reproduce issue
1. Start the supervisor without an existing configuration.
2. Inspect the generated `supervisor_config.properties`.
3. The previous default used `listen-addr=0.0.0.0:36900` with an empty `secret-key`.

## Testing

```powershell
.\gradlew.bat :supervisor-core:test --tests "net.lax1dude.eaglercraft.backend.supervisor.config.EaglerXSupervisorConfigTest" --rerun-tasks
.\gradlew.bat :supervisor-core:build
```